### PR TITLE
🐛 KakaoLogin has only one sessionCallback

### DIFF
--- a/library/src/main/java/com/github/windsekirun/rxsociallogin/kakao/KakaoLogin.kt
+++ b/library/src/main/java/com/github/windsekirun/rxsociallogin/kakao/KakaoLogin.kt
@@ -58,6 +58,12 @@ class KakaoLogin constructor(activity: androidx.fragment.app.FragmentActivity) :
 
     override fun login() {
         checkSession()
+
+        if (sessionCallback != null) {
+            Session.getCurrentSession().removeCallback(sessionCallback)
+            sessionCallback = null
+        }
+
         sessionCallback = SessionCallback()
 
         val session = Session.getCurrentSession()

--- a/library/src/main/java/com/github/windsekirun/rxsociallogin/kakao/KakaoLogin.kt
+++ b/library/src/main/java/com/github/windsekirun/rxsociallogin/kakao/KakaoLogin.kt
@@ -59,15 +59,10 @@ class KakaoLogin constructor(activity: androidx.fragment.app.FragmentActivity) :
     override fun login() {
         checkSession()
 
-        if (sessionCallback != null) {
-            Session.getCurrentSession().removeCallback(sessionCallback)
-            sessionCallback = null
-        }
-
+        removeSessionCallback()
         sessionCallback = SessionCallback()
 
         val session = Session.getCurrentSession()
-
         session.addCallback(sessionCallback)
         if (!session.checkAndImplicitOpen()) {
             val config = getPlatformConfig(PlatformType.KAKAO) as KakaoConfig
@@ -80,9 +75,7 @@ class KakaoLogin constructor(activity: androidx.fragment.app.FragmentActivity) :
         super.onDestroy()
         checkSession()
 
-        if (sessionCallback != null) {
-            Session.getCurrentSession().removeCallback(sessionCallback)
-        }
+        removeSessionCallback()
     }
 
     override fun logout(clearToken: Boolean) {
@@ -183,5 +176,12 @@ class KakaoLogin constructor(activity: androidx.fragment.app.FragmentActivity) :
                 callbackAsSuccess(item)
             }
         })
+    }
+
+    private fun removeSessionCallback() {
+        if (sessionCallback != null) {
+            Session.getCurrentSession().removeCallback(sessionCallback)
+            sessionCallback = null
+        }
     }
 }


### PR DESCRIPTION
# Problem
`KakaoLogin.login`: create new sessionCallback instance and add sessionCallback using `addCallback`

And It doesn't clear. So, multiple callbacks are registered in same time.

# ChangeLog
`KakaoLogin.login()`'s logic is changed.

## As-is
1. create new sessionCallback instance
2. add callback

## To-be
1. if it already has sessionCallback instance, then removeCallback
2. create new sessionCallback instance
3. add callback